### PR TITLE
Add dirty mode for sync

### DIFF
--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -166,6 +166,11 @@ def carbon_sync():
         help='Pass option(s) to rsync. Make sure to use ' +
         '"--rsync-options=" if option starts with \'-\'')
 
+    parser.add_argument(
+        '--dirty',
+        action='store_true',
+        help="If set, don't clean temporary rsync directory")
+
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -194,14 +199,14 @@ def carbon_sync():
             print "* Running batch %s-%s" \
                   % (total_metrics-batch_size+1, total_metrics)
             run_batch(metrics_to_sync, remote,
-                      args.storage_dir, args.rsync_options)
+                      args.storage_dir, args.rsync_options, args.dirty)
             metrics_to_sync = []
 
     if len(metrics_to_sync) > 0:
         print "* Running batch %s-%s" \
               % (total_metrics-len(metrics_to_sync)+1, total_metrics)
         run_batch(metrics_to_sync, remote,
-                  args.storage_dir, args.rsync_options)
+                  args.storage_dir, args.rsync_options, args.dirty)
 
     elapsed = (time() - start)
 

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -199,7 +199,8 @@ def carbon_sync():
             print "* Running batch %s-%s" \
                   % (total_metrics-batch_size+1, total_metrics)
             run_batch(metrics_to_sync, remote,
-                      args.storage_dir, args.rsync_options, remote_ip, args.dirty)
+                      args.storage_dir, args.rsync_options,
+                      remote_ip, args.dirty)
             metrics_to_sync = []
 
     if len(metrics_to_sync) > 0:

--- a/carbonate/cli.py
+++ b/carbonate/cli.py
@@ -199,14 +199,14 @@ def carbon_sync():
             print "* Running batch %s-%s" \
                   % (total_metrics-batch_size+1, total_metrics)
             run_batch(metrics_to_sync, remote,
-                      args.storage_dir, args.rsync_options, args.dirty)
+                      args.storage_dir, args.rsync_options, remote_ip, args.dirty)
             metrics_to_sync = []
 
     if len(metrics_to_sync) > 0:
         print "* Running batch %s-%s" \
               % (total_metrics-len(metrics_to_sync)+1, total_metrics)
         run_batch(metrics_to_sync, remote,
-                  args.storage_dir, args.rsync_options, args.dirty)
+                  args.storage_dir, args.rsync_options, remote_ip, args.dirty)
 
     elapsed = (time() - start)
 

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -91,8 +91,8 @@ def heal_metric(source, dest):
             logging.warn("Failed to copy %s! %s" % (dest, e))
 
 
-def run_batch(metrics_to_sync, remote, local_storage, rsync_options, dirty):
-    staging_dir = mkdtemp(prefix=remote)
+def run_batch(metrics_to_sync, remote, local_storage, rsync_options, remote_ip, dirty):
+    staging_dir = mkdtemp(prefix=remote_ip)
     sync_file = NamedTemporaryFile(delete=False)
 
     metrics_to_heal = []

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -92,7 +92,7 @@ def heal_metric(source, dest):
 
 
 def run_batch(metrics_to_sync, remote, local_storage, rsync_options):
-    staging_dir = mkdtemp()
+    staging_dir = mkdtemp(prefix=remote)
     sync_file = NamedTemporaryFile(delete=False)
 
     metrics_to_heal = []

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -91,7 +91,8 @@ def heal_metric(source, dest):
             logging.warn("Failed to copy %s! %s" % (dest, e))
 
 
-def run_batch(metrics_to_sync, remote, local_storage, rsync_options, remote_ip, dirty):
+def run_batch(metrics_to_sync, remote, local_storage, rsync_options,
+              remote_ip, dirty):
     staging_dir = mkdtemp(prefix=remote_ip)
     sync_file = NamedTemporaryFile(delete=False)
 
@@ -124,8 +125,8 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options, remote_ip, 
 
     # Cleanup
     if dirty:
-      print "    dirty mode: left temporary directory %s" % staging_dir
+        print "    dirty mode: left temporary directory %s" % staging_dir
     else:
-      rmtree(staging_dir)
+        rmtree(staging_dir)
 
     os.unlink(sync_file.name)

--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -91,7 +91,7 @@ def heal_metric(source, dest):
             logging.warn("Failed to copy %s! %s" % (dest, e))
 
 
-def run_batch(metrics_to_sync, remote, local_storage, rsync_options):
+def run_batch(metrics_to_sync, remote, local_storage, rsync_options, dirty):
     staging_dir = mkdtemp(prefix=remote)
     sync_file = NamedTemporaryFile(delete=False)
 
@@ -123,5 +123,9 @@ def run_batch(metrics_to_sync, remote, local_storage, rsync_options):
     print "    Total time: %ss" % total_time
 
     # Cleanup
-    rmtree(staging_dir)
+    if dirty:
+      print "    dirty mode: left temporary directory %s" % staging_dir
+    else:
+      rmtree(staging_dir)
+
     os.unlink(sync_file.name)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint
+envlist = py26,py27,py26-pre0_9_10,py27-pre0_9_10,lint
 
 [testenv]
 install_command = pip install --install-option='--install-scripts={envbindir}' --install-option='--install-lib={envsitepackagesdir}' --install-option='--install-data={envdir}/lib/graphite' -r{toxinidir}/requirements.txt -r{toxinidir}/tests/requirements.txt --pre {opts} {packages}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py26-pre0_9_10,py27-pre0_9_10,lint
+envlist = lint
 
 [testenv]
 install_command = pip install --install-option='--install-scripts={envbindir}' --install-option='--install-lib={envsitepackagesdir}' --install-option='--install-data={envdir}/lib/graphite' -r{toxinidir}/requirements.txt -r{toxinidir}/tests/requirements.txt --pre {opts} {packages}


### PR DESCRIPTION
To help debugging, this PR makes temporary directories used by rsync named after the remote server and let the user the ability to keep them after sync.

This will also help to verify properties (checksums) after the sync to be able to delete metric on the origin remote.